### PR TITLE
In LiquidCrystal.cpp, write(uint8_t value) modified

### DIFF
--- a/BitbloqLiquidCrystal/BitbloqLiquidCrystal.cpp
+++ b/BitbloqLiquidCrystal/BitbloqLiquidCrystal.cpp
@@ -325,6 +325,7 @@ inline void LiquidCrystal::command(uint8_t value) {
 
 inline  size_t LiquidCrystal::write(uint8_t value) {
   send(value, HIGH);
+  return 1;
 }
 
 /************ low level data pushing commands **********/


### PR DESCRIPTION
In LiquidCrystal.cpp, write(uint8_t value) modified, last version did't return anything. Problem comes with new versions of Arduino IDE (at least with 1.6.8 version), if you use the "print("Something") function it doesn't prints the whole message in the LCD, it just prints first character ("S"), with the "return 1;" added it prints the whole word or words. Thanks!
